### PR TITLE
Fix for kernel 6.11.x

### DIFF
--- a/dkms-install.sh
+++ b/dkms-install.sh
@@ -15,7 +15,7 @@ DRV_VERSION=5.4.1
 cp -r ${DRV_DIR} /usr/src/${DRV_NAME}-${DRV_VERSION}
 
 dkms add -m ${DRV_NAME} -v ${DRV_VERSION}
-dkms build -m ${DRV_NAME} -v ${DRV_VERSION}
+dkms build -j $(nproc) -m ${DRV_NAME} -v ${DRV_VERSION}
 dkms install -m ${DRV_NAME} -v ${DRV_VERSION}
 RESULT=$?
 

--- a/os_dep/linux/ioctl_cfg80211.c
+++ b/os_dep/linux/ioctl_cfg80211.c
@@ -417,15 +417,16 @@ u8 rtw_cfg80211_ch_switch_notify(_adapter *adapter, u8 ch, u8 bw, u8 offset, u8 
 	if (ret != _SUCCESS)
 		goto exit;
 
-#if (LINUX_VERSION_CODE >= KERNEL_VERSION(5, 19, 2))
-#if (LINUX_VERSION_CODE >= KERNEL_VERSION(6, 8, 0))
-	cfg80211_ch_switch_notify(adapter->pnetdev, &chdef, 0, 0);
+#if (LINUX_VERSION_CODE >= KERNEL_VERSION(6, 11, 0))
+       cfg80211_ch_switch_notify(adapter->pnetdev, &chdef, 0);
+#elif (LINUX_VERSION_CODE >= KERNEL_VERSION(6, 8, 0))
+       cfg80211_ch_switch_notify(adapter->pnetdev, &chdef, 0, 0);
+#elif (LINUX_VERSION_CODE >= KERNEL_VERSION(5, 19, 2))
+       cfg80211_ch_switch_notify(adapter->pnetdev, &chdef, 0);
 #else
-	cfg80211_ch_switch_notify(adapter->pnetdev, &chdef, 0);
+       cfg80211_ch_switch_notify(adapter->pnetdev, &chdef);
 #endif
-#else
-	cfg80211_ch_switch_notify(adapter->pnetdev, &chdef);
-#endif
+
 
 #else
 	int freq = rtw_ch2freq(ch);


### PR DESCRIPTION
This PR fixes the following compilation error:

```c
  CC [M]  rtl8821CU/os_dep/linux/ioctl_cfg80211.o
rtl8821CU/os_dep/linux/ioctl_cfg80211.c: In function ‘rtw_cfg80211_ch_switch_notify’:
rtl8821CU/os_dep/linux/ioctl_cfg80211.c:422:9: error: too many arguments to function ‘cfg80211_ch_switch_notify’
  422 |         cfg80211_ch_switch_notify(adapter->pnetdev, &chdef, 0, 0);
      |         ^~~~~~~~~~~~~~~~~~~~~~~~~
```

I took some care not to break earlier kernel versions and also added `$(nproc)` to speed up compile times.